### PR TITLE
Cjp/launch updates

### DIFF
--- a/lib/cypressReporter.js
+++ b/lib/cypressReporter.js
@@ -196,12 +196,13 @@ class CypressReporter extends Mocha.reporters.Base {
   }
 
   static shouldStopLaunch() {
-    return (
-      !CypressReporter.totalLaunches ||
-      CypressReporter.currentLaunch === CypressReporter.totalLaunches ||
-      !CypressReporter.reporterOptions.autoMerge ||
-      CypressReporter.reporterOptions.parallel
-    );
+    // return (
+    //   !CypressReporter.totalLaunches ||
+    //   CypressReporter.currentLaunch === CypressReporter.totalLaunches ||
+    //   !CypressReporter.reporterOptions.autoMerge ||
+    //   CypressReporter.reporterOptions.parallel
+    // );
+    return false;
   }
 
   static shouldStartLaunch() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -127,6 +127,7 @@ const getLaunchStartObject = (config) => {
   );
 
   return {
+    id: config.reporterOptions.id,
     launch: config.reporterOptions.launch,
     description: config.reporterOptions.description,
     attributes: launchAttributes,


### PR DESCRIPTION
Updating the reporter to work with our Jenkins runs

The ability to stop a launch from the reporter has been temporarily disabled. We'll need to include logic later to make this flexible. In the meantime we should not do local runs. Open is being updated as well to put this reporting behind an enable flag so we can turn it off for local runs